### PR TITLE
fix(readme): usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Add the plugin to your ESLint config:
 ```json
 {
   "extends": [
-    "plugin:import-alias/recommended"
+    "plugin:@dword-design/import-alias/recommended"
   ],
 }
 ```


### PR DESCRIPTION
The current instructions suggest using the wrong plugin. When using such configuration and running ESLint, we get the following error:

```bash
ESLint couldn't find the plugin "eslint-plugin-import-alias".
```

Closes #74.