### PR TITLE
feat: add option to allow subpath with alias

### DIFF
--- a/src/rules/prefer-alias.js
+++ b/src/rules/prefer-alias.js
@@ -92,7 +92,11 @@ export default {
         }
 
         const importWithoutAlias = resolvePath(sourcePath, currentFile, options)
-        if (!(importWithoutAlias |> isParentImport) && hasAlias) {
+        if (
+          !(importWithoutAlias |> isParentImport) &&
+          hasAlias &&
+          !options.allowSubpathWithAlias
+        ) {
           return context.report({
             fix: fixer =>
               fixer.replaceTextRange(
@@ -116,6 +120,10 @@ export default {
         properties: {
           alias: {
             type: 'object',
+          },
+          allowSubpathWithAlias: {
+            default: false,
+            type: 'boolean',
           },
         },
         type: 'object',

--- a/src/rules/prefer-alias.spec.js
+++ b/src/rules/prefer-alias.spec.js
@@ -77,6 +77,22 @@ export default tester(
         output: "import foo from './foo'",
       })
     },
+    'allow subpath with alias': async () => {
+      await outputFiles({
+        '.babelrc.json': JSON.stringify({
+          plugins: [
+            [
+              packageName`babel-plugin-module-resolver`,
+              { alias: { '@': '.' }, allowSubpathWithAlias: false },
+            ],
+          ],
+        }),
+        'foo.js': '',
+      })
+      expect(
+        lint("import foo from '@/foo'", { filename: 'sub/index.js' }).messages,
+      ).toEqual([])
+    },
     'custom alias': async () => {
       await outputFiles({
         'foo.js': '',


### PR DESCRIPTION
Hello

To make sure all my team members always apply aliases on all imports (it's simpler to apply the same rule everywhere ;-)) I need to patch your project to allow this.
So I propose you to add an option flag `allowSubpathWithAlias` through this PR to allow this feature. This flag is obviously disabled by default to keep the current behavior.
I also added new unit test.