### PR TITLE
Add options to enable aliases for siblings and subpaths

### DIFF
--- a/src/rules/prefer-alias.spec.js
+++ b/src/rules/prefer-alias.spec.js
@@ -43,6 +43,68 @@ const lint = (code, options = {}) => {
 
 export default tester(
   {
+    'alias for siblings': async () => {
+      await outputFiles({
+        '.babelrc.json': JSON.stringify({
+          plugins: [
+            [
+              packageName`babel-plugin-module-resolver`,
+              { alias: { '@': '.' } },
+            ],
+          ],
+        }),
+        'foo.js': '',
+      })
+      expect(
+        lint("import foo from './foo'", {
+          eslintConfig: {
+            rules: {
+              'self/self': [
+                'error',
+                {
+                  forSiblings: true,
+                },
+              ],
+            },
+          },
+        }),
+      ).toEqual({
+        messages: ["Unexpected sibling import './foo'. Use '@/foo' instead"],
+        output: "import foo from '@/foo'",
+      })
+    },
+    'alias for subpaths': async () => {
+      await outputFiles({
+        '.babelrc.json': JSON.stringify({
+          plugins: [
+            [
+              packageName`babel-plugin-module-resolver`,
+              { alias: { '@': '.' } },
+            ],
+          ],
+        }),
+        'sub/foo.js': '',
+      })
+      expect(
+        lint("import foo from './sub/foo'", {
+          eslintConfig: {
+            rules: {
+              'self/self': [
+                'error',
+                {
+                  forSubpaths: true,
+                },
+              ],
+            },
+          },
+        }),
+      ).toEqual({
+        messages: [
+          "Unexpected subpath import './sub/foo'. Use '@/sub/foo' instead",
+        ],
+        output: "import foo from '@/sub/foo'",
+      })
+    },
     'alias parent': async () => {
       await outputFiles({
         '.babelrc.json': JSON.stringify({


### PR DESCRIPTION
Hello,

This is a continuation of #130 (which has been closed by its author) and closes #133.

This adds 2 options `forSubpaths` and `forSiblings`, to enable aliases for these specific cases. I separated them because I wanted only siblings (`import from './foo'`) and not subpaths (`import from ./sub/foo`) to be converted to aliases.

I took the liberty to refactor a bit because the previous main conditional branches (`if (sourcePath |> isParentImport)` and `if (!(importWithoutAlias |> isParentImport) && hasAlias)`) were making things too convoluted. Feel free to improve/refactor as you wish.

And lastly, I had to create a `importType` variable to be able to make the tests pass (having _Unexpected **parent** import_ in the eslint message). I would suggest to remove this word for the sake of simplicity, but that would imply updating the tests and I didn't want to take this decision myself.